### PR TITLE
nvme_ctrlr: make configure_aer failing a warning.

### DIFF
--- a/lib/nvme/nvme_ctrlr.c
+++ b/lib/nvme/nvme_ctrlr.c
@@ -700,7 +700,7 @@ static int nvme_ctrlr_start(struct nvme_ctrlr *ctrlr)
 		return -1;
 
 	if (nvme_ctrlr_configure_aer(ctrlr) != 0)
-		return -1;
+		nvme_warning("controller does not support AER!\n");
 
 	nvme_ctrlr_set_supported_log_pages(ctrlr);
 	nvme_ctrlr_set_supported_features(ctrlr);


### PR DESCRIPTION
The spec generally requires this feature, but some emulated hardware (e.g. QEMU) does not support it. SPDK seems to just ignore the error and continue on with a warning, so let's do the same here.

This fix comes originally from Haiku (commit: https://github.com/haiku/haiku/commit/8bb337b5fe7269387cd381652c9cbf254fcfdda5), where we've made libnvme the basis for our kernel-space NVMe driver.

There are some other fixes I'd like to upstream after this (e.g. making the main header includeable as C++) as well as some other changes you may be less amenable too (e.g. moving PCI device detection into a sort of abstraction layer, to hook into our kernel APIs instead of libpciaccess), and some other changes I've not yet started (e.g. doing more locking inside libnvme so all calls are threadsafe).